### PR TITLE
use FLAG_IMMUTABLE for PendingIntents

### DIFF
--- a/src/app/seamlessupdate/client/NotificationHandler.java
+++ b/src/app/seamlessupdate/client/NotificationHandler.java
@@ -45,7 +45,8 @@ public class NotificationHandler {
     }
 
     void showRebootNotification() {
-        final PendingIntent reboot = PendingIntent.getBroadcast(context, PENDING_REBOOT_ID, new Intent(context, RebootReceiver.class), 0);
+        final PendingIntent reboot = PendingIntent.getBroadcast(context, PENDING_REBOOT_ID,
+                        new Intent(context, RebootReceiver.class), PendingIntent.FLAG_IMMUTABLE);
 
         final NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID,
                 context.getString(R.string.notification_channel), NotificationManager.IMPORTANCE_HIGH);
@@ -84,7 +85,8 @@ public class NotificationHandler {
     }
 
     private PendingIntent getPendingSettingsIntent() {
-        return PendingIntent.getActivity(context, PENDING_SETTINGS_ID, new Intent(context, Settings.class), 0);
+        return PendingIntent.getActivity(context, PENDING_SETTINGS_ID, new Intent(context,
+                                Settings.class), PendingIntent.FLAG_IMMUTABLE);
     }
 
 }


### PR DESCRIPTION
See CVE-2020-0396 in September security bulletin, but not likely to be serious since Updater isn't a priv_app now (https://github.com/GrapheneOS/platform_system_sepolicy/commit/33fa92c37dd0101164a55ea1584cef6450fa641b), and SystemUI gets the PendingIntents via notifications and SystemUI is trusted