### PR TITLE
support metadata signature verification using otacerts.zip

### DIFF
--- a/src/app/seamlessupdate/client/MetadataSignatureVerifier.java
+++ b/src/app/seamlessupdate/client/MetadataSignatureVerifier.java
@@ -1,0 +1,89 @@
+package app.seamlessupdate.client;
+
+import android.util.Log;
+
+import androidx.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+public class MetadataSignatureVerifier {
+    private static final String TAG = MetadataSignatureVerifier.class.getSimpleName();
+    private static final String OTA_CERTS_ZIP_PATH = "/system/etc/security/otacerts.zip";
+    @Nullable
+    private static PublicKey releasePublicKey = getPubKeyFromOTACertsZip();
+    /**
+     * Determined by the script the generates keys: development/tools/make_key;
+     * and the script used to generate metadata: script/generate_metadata.py
+     **/
+    private static final String SIGNING_ALGORITHM = "SHA256withRSA/PSS";
+
+    @Nullable
+    private static PublicKey getPubKeyFromOTACertsZip() {
+        final ArrayList<X509Certificate> certificates = new ArrayList<>();
+        try (final ZipFile otaCertsZip = new ZipFile(new File(OTA_CERTS_ZIP_PATH))) {
+            final CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+            final Enumeration<? extends ZipEntry> entries = otaCertsZip.entries();
+            while (entries.hasMoreElements()) {
+                final ZipEntry entry = entries.nextElement();
+                try (final InputStream inputStream = otaCertsZip.getInputStream(entry)) {
+                    certificates.add((X509Certificate) certificateFactory.generateCertificate(inputStream));
+                }
+            }
+        } catch (IOException | CertificateException e) {
+            Log.w(TAG, "unable to get OTA certificates", e);
+            return null;
+        }
+        if (certificates.isEmpty()) {
+            Log.w(TAG, "unable to find any OTA certs");
+            return null;
+        }
+        if (certificates.size() > 1) {
+            Log.w(TAG, "more than one OTA cert found");
+        }
+
+        return certificates.get(0).getPublicKey();
+    }
+
+    public static void verifyMetadata(byte[] metadata, byte[] signature)
+            throws GeneralSecurityException {
+        if (releasePublicKey == null) {
+            // Try again
+            releasePublicKey = getPubKeyFromOTACertsZip();
+            if (releasePublicKey == null) {
+                throw new GeneralSecurityException("was unable to find public key");
+            }
+        }
+
+        final Signature verifier;
+        try {
+            verifier = Signature.getInstance(SIGNING_ALGORITHM);
+        } catch (NoSuchAlgorithmException e) {
+            throw new GeneralSecurityException("failed to get an instance of " + SIGNING_ALGORITHM);
+        }
+
+        try {
+            verifier.initVerify(releasePublicKey);
+            verifier.update(metadata);
+            if (!verifier.verify(signature)) {
+                throw new GeneralSecurityException("verifier.verify returned false");
+            }
+        } catch (InvalidKeyException | SignatureException e) {
+            throw new GeneralSecurityException("failed to verify signature, exception", e);
+        }
+    }
+}

--- a/src/app/seamlessupdate/client/Service.java
+++ b/src/app/seamlessupdate/client/Service.java
@@ -9,6 +9,7 @@ import static android.os.UpdateEngine.UpdateStatusConstants.FINALIZING;
 import android.app.IntentService;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.PowerManager;
 import android.os.PowerManager.WakeLock;
 import android.os.RecoverySystem;
@@ -258,6 +259,10 @@ public class Service extends IntentService {
             final String targetChannel = metadata[3];
             if (!targetChannel.equals(channel)) {
                 throw new GeneralSecurityException("targetChannel: " + targetChannel + " does not match channel: " + channel);
+            }
+            final String targetDevice = metadata[4];
+            if (!DEVICE.equals(targetDevice)) {
+                throw new GeneralSecurityException("targetDevice: " + targetDevice + " does not match device: " + DEVICE);
             }
 
             String downloadFile = preferences.getString(PREFERENCE_DOWNLOAD_FILE, null);


### PR DESCRIPTION
Closes #7 

Needs to be looked at with https://github.com/GrapheneOS/script/pull/8

This PR adds metadata signature verification. It also verifies the new added device model
field in the metadata as noted in #7.

For RSA, we sign using RSASSA-PSS as recommended for new applications in PKCS #`1
v2.2 (RFC 8017) [1]. SHA256withRSA/PSS is supported on Android [2].

Test: With a self-hosted server, a GeneralSecurityException is thrown in
Service when the metadata doesn't match with the original contents, and
no GeneralSecurityException when it matches.

Test: The following steps were done successfully with an RSA-2048
release key and then repeated with an RSA-4096 release key and an
ECDSA release key (generated from `development/tools/make_key`):
1. Flash latest factory zip and boot the OS and have the
latest version also on the server
2. Check for updates on the server (sargo-stable) with a correct
signature to get the "targetBuildDate: ... not higher than
sourceBuildDate" message
3. Edit sargo-stable on the server to something different, and check
again for updates in the app. The logcat shows
java.security.GeneralSecurityException: verifier.verify returned false
4. Repeat steps 2-3 for the beta and testing channels
5. Upload a newer release with the metadata altered from the correct
value; the same exception from step 3 shows up
6. Change metadata to correct value; the update downloads and installs
correctly.

Test: A previous version of the Updater app was able to download and
verify the new metadata format without issues.

[1] https://tools.ietf.org/html/rfc8017#section-8
[2] https://developer.android.com/reference/java/security/Signature