### PR TITLE
Add Confirmation Dialog for Manual Updates on Metered/Roaming Networks

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -61,4 +61,6 @@ The only difference between regular releases and security preview releases are t
     <string name="security_preview_settings_error_saving">An error occurred trying to save security preview releases setting</string>
     <string name="next">Next</string>
     <string name="save">Save</string>
+    <string name="alert_metered_network">You\'re connected to a metered network. Continuing may use mobile data and result in extra charges. Proceed?</string>
+    <string name="alert_roaming_network">You\'re on a roaming network. Continuing may incur additional data charges. Proceed?</string>
 </resources>

--- a/src/app/seamlessupdate/client/Settings.java
+++ b/src/app/seamlessupdate/client/Settings.java
@@ -5,10 +5,13 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.ConnectivityManager;
+import android.net.NetworkCapabilities;
 import android.os.Bundle;
 import android.os.UserManager;
 import android.util.Log;
 import android.view.MenuItem;
+import android.app.job.JobInfo;
+import android.app.AlertDialog;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -104,6 +107,20 @@ public class Settings extends CollapsingToolbarBaseActivity {
             implements SharedPreferences.OnSharedPreferenceChangeListener {
         private static String TAG = "SettingsFragment";
 
+        private void showAlertDialogForMismatchedNetwork(final Context context, final Network network, final int messageId) {
+            new AlertDialog.Builder(context)
+                .setTitle(android.R.string.dialog_alert_title)
+                .setMessage(messageId)
+                .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+                    final var intent = new Intent(context, Service.class);
+                    intent.putExtra(Service.INTENT_EXTRA_IS_USER_INITIATED, true);
+                    intent.putExtra(Service.INTENT_EXTRA_NETWORK, network);
+                    context.startForegroundService(intent);
+                })
+                .setNegativeButton(android.R.string.cancel, (dialog, which) -> {})
+                .show();
+        }
+
         @Override
         public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
             getPreferenceManager().setStorageDeviceProtected();
@@ -116,6 +133,19 @@ public class Settings extends CollapsingToolbarBaseActivity {
                     final Network network = connectivityManager.getActiveNetwork();
                     if (network == null) {
                         Log.w(TAG, "checkForUpdates.onClickListener – network will be unavailable");
+                    } else {
+                        final int networkType = Settings.getNetworkType(context);
+                        final NetworkCapabilities networkCapabilities = connectivityManager.getNetworkCapabilities(network);
+                        if (networkCapabilities != null && networkType == JobInfo.NETWORK_TYPE_UNMETERED 
+                            && !networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)) {
+                                showAlertDialogForMismatchedNetwork(context, network, R.string.alert_metered_network);
+                                return true;
+                        }
+                        if (networkCapabilities != null && networkType == JobInfo.NETWORK_TYPE_NOT_ROAMING 
+                            && !networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_ROAMING)) {
+                                showAlertDialogForMismatchedNetwork(context, network, R.string.alert_roaming_network);
+                                return true;
+                        }
                     }
                     final var intent = new Intent(context, Service.class);
                     intent.putExtra(Service.INTENT_EXTRA_IS_USER_INITIATED, true);


### PR DESCRIPTION
**Description:**

This PR improves the System Updater by notifying users when they attempt a manual update check while connected to a network that does not match the network properties required for automatic updates (e.g., metered or roaming). Previously, network restrictions were enforced only for background updates. Manual update checks bypassed these settings, which could result in unintended data charges.

With this change, the user will be prompted with an alert dialog if the current network does not match the configured properties. The update check will proceed only if the user explicitly confirms.

**Changes:**

- Added confirmation dialog when the user manually checks for updates on a network that does not match the configured permitted network properties.
- If confirmed, the update check proceeds by starting the service as user-initiated. If the user cancels, the check is aborted and the service is not started.
- Background update behavior remains unchanged.

**Testing:**

Tested with Pixel 6a on the `16-qpr2` branch to ensure:
- Update check works normally on permitted networks.
- Alert dialog appears correctly when attempting a manual check on a metered network.
- User confirmation correctly controls whether the update check proceeds.

Screenshot from the testing can be found below.

 I am happy to revise and resubmit the code if any changes are desired.

<div>
  <img width="48%" height="2400" alt="Screenshot_20260601-233224" src="https://github.com/user-attachments/assets/d371f69c-1b24-4d03-9c45-c6d52048f1a7" />
  <img width="48%" height="2400" alt="Screenshot_20260601-233256" src="https://github.com/user-attachments/assets/9447fd4b-096f-40e3-b223-585ce95fa4e1" />
</div>

