### PR TITLE
notification timeout fix + block users from disabling reboot, security preview, and failure notifications

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -12,9 +12,17 @@ android_app {
     platform_apis: true,
     privileged: true,
     required: [
+        "etc_default-permissions_app.seamlessupdate.client.xml",
         "etc_permissions_app.seamlessupdate.client.xml",
         "etc_sysconfig_app.seamlessupdate.client.xml",
     ]
+}
+
+prebuilt_etc {
+    name: "etc_default-permissions_app.seamlessupdate.client.xml",
+    src: "etc/default-permissions/app.seamlessupdate.client.xml",
+    sub_dir: "default-permissions",
+    filename_from_src: true,
 }
 
 prebuilt_etc {

--- a/etc/default-permissions/app.seamlessupdate.client.xml
+++ b/etc/default-permissions/app.seamlessupdate.client.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<exceptions>
+    <exception package="app.seamlessupdate.client">
+        <permission name="android.permission.POST_NOTIFICATIONS" fixed="true"/>
+    </exception>
+</exceptions>

--- a/src/app/seamlessupdate/client/NotificationHandler.java
+++ b/src/app/seamlessupdate/client/NotificationHandler.java
@@ -54,8 +54,11 @@ public class NotificationHandler {
         var notificationManager = context.getSystemService(NotificationManager.class);
         final List<NotificationChannel> channels = new ArrayList<>();
 
-        channels.add(new NotificationChannel(NOTIFICATION_CHANNEL_ID_PROGRESS,
-                context.getString(R.string.notification_channel_progress), IMPORTANCE_LOW));
+        // channels are unblockable by default with fixed notification permission
+        final NotificationChannel progress = new NotificationChannel(NOTIFICATION_CHANNEL_ID_PROGRESS,
+                context.getString(R.string.notification_channel_progress), IMPORTANCE_LOW);
+        progress.setBlockable(true);
+        channels.add(progress);
 
         final NotificationChannel reboot = new NotificationChannel(NOTIFICATION_CHANNEL_ID_REBOOT,
                 context.getString(R.string.notification_channel_reboot), IMPORTANCE_HIGH);
@@ -63,12 +66,15 @@ public class NotificationHandler {
         reboot.enableVibration(true);
         channels.add(reboot);
 
-        channels.add(new NotificationChannel(NOTIFICATION_CHANNEL_ID_FAILURE,
-                context.getString(R.string.notification_channel_failure), IMPORTANCE_LOW));
+        final NotificationChannel failure = new NotificationChannel(NOTIFICATION_CHANNEL_ID_FAILURE,
+                context.getString(R.string.notification_channel_failure), IMPORTANCE_LOW);
+        failure.setBlockable(true);
+        channels.add(failure);
 
         final NotificationChannel updated = new NotificationChannel(NOTIFICATION_CHANNEL_ID_UPDATED,
                 context.getString(R.string.notification_channel_updated), IMPORTANCE_MIN);
         updated.setShowBadge(false);
+        updated.setBlockable(true);
         channels.add(updated);
 
         final NotificationChannel setSecurityPreview = new NotificationChannel(NOTIFICATION_CHANNEL_ID_SET_SECURITY_PREVIEW,

--- a/src/app/seamlessupdate/client/NotificationHandler.java
+++ b/src/app/seamlessupdate/client/NotificationHandler.java
@@ -184,6 +184,7 @@ public class NotificationHandler {
                 .setContentText(service.getString(R.string.notification_reboot_text))
                 .setOngoing(true)
                 .setShowWhen(true)
+                .setTimeoutAfter(-1)
                 .setSmallIcon(R.drawable.system_update_fill0_wght400_grad0_opsz48)
                 .build());
     }
@@ -243,6 +244,7 @@ public class NotificationHandler {
                 .setContentText(context.getString(contentResId))
                 .setOngoing(true)
                 .setShowWhen(true)
+                .setTimeoutAfter(-1)
                 .setSmallIcon(R.drawable.security_update_warning_fill0_wght400_grad0_opsz48)
                 .build());
     }

--- a/src/app/seamlessupdate/client/NotificationHandler.java
+++ b/src/app/seamlessupdate/client/NotificationHandler.java
@@ -68,7 +68,6 @@ public class NotificationHandler {
 
         final NotificationChannel failure = new NotificationChannel(NOTIFICATION_CHANNEL_ID_FAILURE,
                 context.getString(R.string.notification_channel_failure), IMPORTANCE_LOW);
-        failure.setBlockable(true);
         channels.add(failure);
 
         final NotificationChannel updated = new NotificationChannel(NOTIFICATION_CHANNEL_ID_UPDATED,


### PR DESCRIPTION
### prevent reboot + security preview notifications from timing out

Closes #117

### block users from disabling the reboot and security preview notifications

This reverts commit 5fa7f8279c826c68f71c4bad356b681f4508e427. Conflicts are resolved, and the new security preview notification is marked as non-blockable.

Tested that turning the reboot notification off will result in it enabled (and unblockable) upon update.
All other notification settings besides security preview and reboot notifications preserve their settings
after update.

There is a case where I can reproduce the original issue of all the `NotificationChannel`s being
unblockable by doing the following:

- Revert the "refactor notification handling" commit, and
- Setting up conditions in Updater that would prevent a periodic update check after reboot

I reverted the refactor commit to try to reproduce the issue using the old behavior where the
`NotificationChannel` creation is done in the `onCreate` method of the `Service`. After the revert,
the new `NotificationChannel#setBlockable` calls wouldn't be active until a periodic or forced
update check happens (i.e. a `Service` is created)

This can happen quite easily, e.g.,

1. Someone can set it to require charging for periodic update checks
2. Then after update finishes, during the reboot, they unplug from charger (and maybe leave their
house)
3. With the new Updater version, the fixed notification permission will make all channels
unblockable by default
4. A periodic check or a forced update check from the Updater settings is now required for the
`setBlockable(true)` calls to come into effect from the `Service`'s `onCreate` (one-time thing) to
opt in certain channels to being blockable.
5. Periodic check doesn't happen because phone is not charging, so notification channels remain
unblockable until they charge phone + have internet for the `Service` to run again
6. If they don't plug in their phone for a long time (not uncommon behavior), a user might've
noticed this issue of all channels being unblockable and reported it

Theoretically this bug, or at least this specific case of the bug, is fixed by the
"refactor notification handling" commit. `NotificationChannel`s would always be created (and thus
updated with the new `setBlockable` calls) on `Application `start instead of being limited to the
`Service#onCreate`.  The `Service` can be delayed for many reasons, so it's not an ideal place to
put `NotificationChannel` code.

It's unknown if there are other cases where all the channels become unblockable.