### PR TITLE
Service: fix streaming-suffix strip and drop unused channel parameter

### DIFF
--- a/src/app/seamlessupdate/client/Service.java
+++ b/src/app/seamlessupdate/client/Service.java
@@ -121,8 +121,8 @@ public class Service extends IntentService {
         engine.bind(callback);
         if (streaming) {
             final SharedPreferences preferences = Settings.getPreferences(this);
-            final String downloadFile = preferences.getString(PREFERENCE_DOWNLOAD_FILE.replace("-streaming", ""), null);
-            engine.applyPayload(getString(R.string.url) + downloadFile, payloadOffset, 0, headerKeyValuePairs);
+            final String downloadFile = preferences.getString(PREFERENCE_DOWNLOAD_FILE, null);
+            engine.applyPayload(getString(R.string.url) + downloadFile.replace("-streaming", ""), payloadOffset, 0, headerKeyValuePairs);
         } else {
             UPDATE_PATH.setReadable(true, false);
             engine.applyPayload("file://" + UPDATE_PATH, payloadOffset, 0, headerKeyValuePairs);

--- a/src/app/seamlessupdate/client/Service.java
+++ b/src/app/seamlessupdate/client/Service.java
@@ -149,7 +149,7 @@ public class Service extends IntentService {
     }
 
     private void onDownloadFinished(final boolean streaming, final long targetBuildDate,
-            final String targetIncremental, final String channel) throws IOException, GeneralSecurityException {
+            final String targetIncremental) throws IOException, GeneralSecurityException {
         try {
             notificationHandler.showVerifyNotification(0);
             RecoverySystem.verifyPackage(UPDATE_PATH, (int progress) -> {
@@ -341,7 +341,7 @@ public class Service extends IntentService {
                 final int responseCode = connection.getResponseCode();
                 if (responseCode == HTTP_RANGE_NOT_SATISFIABLE) {
                     Log.d(TAG, "download completed previously");
-                    onDownloadFinished(streaming, targetBuildDate, targetIncremental, channel);
+                    onDownloadFinished(streaming, targetBuildDate, targetIncremental);
                     return;
                 }
                 if (responseCode == HTTP_NOT_FOUND && incrementalUpdate.equals(downloadFile)) {
@@ -418,7 +418,7 @@ public class Service extends IntentService {
             }
 
             Log.d(TAG, "download completed");
-            onDownloadFinished(streaming, targetBuildDate, targetIncremental, channel);
+            onDownloadFinished(streaming, targetBuildDate, targetIncremental);
         } catch (GeneralSecurityException | IOException | ServiceSpecificException e) {
             Log.e(TAG, "failed to download and install update", e);
             notificationHandler.showFailureNotification(e.getMessage());


### PR DESCRIPTION
### 1. Strip `-streaming` suffix from the saved download file in streaming test mode

In `applyUpdate`, the streaming branch called `.replace("-streaming", "")` on the preference key rather than on the saved value:

```java
preferences.getString(PREFERENCE_DOWNLOAD_FILE.replace("-streaming", ""), null)
```

`PREFERENCE_DOWNLOAD_FILE` is the literal `"download_file"`, which contains no `-streaming` substring, so the replace was a no-op and the URL passed to `applyPayload` kept the `-streaming` suffix. The suffix and the strip were introduced together in 280c3c26, so the intent was always to strip it from the stored file name, not the key. The replace now runs on the returned value, so streaming test mode downloads the `-streaming` file for the metadata and streams the payload from the main update file as intended:

```java
final String downloadFile = preferences.getString(PREFERENCE_DOWNLOAD_FILE, null);
engine.applyPayload(getString(R.string.url) + downloadFile.replace("-streaming", ""), payloadOffset, 0, headerKeyValuePairs);
```

### 2. Remove unused `channel` parameter from `onDownloadFinished`

`onDownloadFinished` took a `String channel` argument from both of its call sites in `onHandleIntent`, but never referenced it in the method body — all metadata/channel checks happen earlier, before the function is called. Dropped the parameter and updated both call sites. The local `channel` variable in `onHandleIntent` is still used for `fetchData`, the `targetChannel` validation, and `showUpdatedNotification`.